### PR TITLE
Convert from a label input list rather than converting a full store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "terminusdb-10-to-11"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "base64",
  "byteorder",

--- a/src/dataconversion.rs
+++ b/src/dataconversion.rs
@@ -92,10 +92,10 @@ pub fn value_string_to_slices(s: &str) -> Result<LangOrType> {
 
         let mut lang = &s[pos + 1..];
         if &lang[0..1] == "\'" || &lang[0..1] == "\"" {
-            lang = &lang[1..lang.len()-1];
+            lang = &lang[1..lang.len() - 1];
         }
 
-        let val = &s[1..pos-1];
+        let val = &s[1..pos - 1];
 
         Ok(LangOrType::Lang(val, lang))
     }
@@ -624,9 +624,7 @@ fn prolog_string_to_string(s: &str) -> Cow<str> {
     }
 
     match result {
-        Some(result) => {
-            Cow::Owned(result)
-        }
+        Some(result) => Cow::Owned(result),
         None => Cow::Borrowed(s),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,9 @@ enum Commands {
         /// The workdir to store mappings in
         #[arg(short = 'w', long = "workdir")]
         workdir: Option<String>,
+        /// Path to a file with a list of labels to convert
+        #[arg(long = "labels")]
+        labels: Option<String>,
         /// Convert the store assuming all values are strings
         #[arg(long = "naive")]
         naive: bool,
@@ -114,6 +117,7 @@ async fn inner_main() -> Result<(), CliError> {
             from,
             to,
             workdir,
+            labels,
             naive,
             keep_going,
             verbose,
@@ -129,6 +133,7 @@ async fn inner_main() -> Result<(), CliError> {
                 &from,
                 &to,
                 workdir.as_deref().unwrap_or(&default_workdir),
+                labels.as_deref(),
                 naive,
                 keep_going,
                 verbose,


### PR DESCRIPTION
This PR introduces a new flag `--labels` which lets you specify a file containing a list of labels to convert.

This allows for a more partial store conversion, just doing a few data products.